### PR TITLE
Fix contact form email template for empty message field

### DIFF
--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -121,7 +121,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
         <div style="background-color: #FAF9F8; padding: 20px; border-radius: 8px;">
           <h3 style="color: #4A5D7A; margin-top: 0;">Message</h3>
-          <p style="white-space: pre-wrap;">${message}</p>
+          <p style="white-space: pre-wrap;">${message || 'No message provided'}</p>
         </div>
 
         <div style="margin-top: 20px; padding: 15px; background-color: #E8F4FD; border-radius: 8px;">


### PR DESCRIPTION
## Summary
- Fixed email template to handle empty message field properly
- Added fallback text 'No message provided' when no message is entered

## Issue
Contact form wasn't sending emails when visitors left the message field empty, even though the field is now optional.

## Solution
Updated email template to display 'No message provided' when message field is empty or undefined, ensuring emails are sent successfully for all form submissions.

## Test plan
- [x] Test form submission with empty message field
- [x] Verify email is sent and displays fallback text
- [x] Confirm form still works normally with message content