### PR TITLE
Update contact form email recipient

### DIFF
--- a/pages/api/contact.ts
+++ b/pages/api/contact.ts
@@ -134,7 +134,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const { data, error } = await resend.emails.send({
       from: 'ClearPoint Contact Form <noreply@clearpointwindowservices.com>',
-      to: ['linc2liam@gmail.com'],
+      to: ['clearpointwindows1@gmail.com'],
       subject: subject ? `Contact Form: ${subject}` : `New Contact Form Submission from ${name}`,
       html: htmlContent,
       replyTo: email,


### PR DESCRIPTION
## Summary
- Updated contact form to send emails to clearpointwindows1@gmail.com instead of linc2liam@gmail.com

## Changes
- Modified email recipient in Resend API configuration
- Ensures all contact form submissions go to the correct business email address

## Test plan
- [x] Verify contact form sends to new email address
- [x] Confirm email delivery works properly
- [x] Test form functionality remains intact