### PR TITLE
Update navigation text to 'About me' across all pages

### DIFF
--- a/components/BestPracticeMobileNav.tsx
+++ b/components/BestPracticeMobileNav.tsx
@@ -12,7 +12,7 @@ export default function BestPracticeMobileNav({ currentPage }: MobileNavProps) {
   const navItems = [
     { href: '/', label: 'Home', id: 'home' },
     { href: '/services', label: 'Services', id: 'services' },
-    { href: '/about', label: 'About us', id: 'about' },
+    { href: '/about', label: 'About me', id: 'about' },
     { href: '/contact', label: 'Contact us', id: 'contact' }
   ]
 

--- a/components/FullScreenMobileNav.tsx
+++ b/components/FullScreenMobileNav.tsx
@@ -11,7 +11,7 @@ export default function FullScreenMobileNav({ currentPage }: FullScreenMobileNav
   const navItems = [
     { href: '/', label: 'Home', id: 'home' },
     { href: '/services', label: 'Services', id: 'services' },
-    { href: '/about', label: 'About us', id: 'about' },
+    { href: '/about', label: 'About me', id: 'about' },
     { href: '/contact', label: 'Contact us', id: 'contact' }
   ]
 

--- a/components/ImprovedMobileNav.tsx
+++ b/components/ImprovedMobileNav.tsx
@@ -69,7 +69,7 @@ export default function ImprovedMobileNav({ currentPage }: ImprovedMobileNavProp
                 fontSize: '16px'
               }}
             >
-              About us
+              About me
             </Link>
             <Link 
               href="/contact" 

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -56,7 +56,7 @@ export default function MobileNav({ currentPage }: MobileNavProps) {
               color: currentPage === 'about' ? '#4A5D7A' : '#2C3E50'
             }}
           >
-            About us
+            About me
           </Link>
           <Link 
             href="/contact" 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -4,7 +4,7 @@ export default function Navigation() {
   const navItems = [
     { href: '/', label: 'Home' },
     { href: '/services', label: 'Services' },
-    { href: '/about', label: 'About us' },
+    { href: '/about', label: 'About me' },
     { href: '/contact', label: 'Free Quote' }
   ]
 

--- a/components/ResponsiveNav.tsx
+++ b/components/ResponsiveNav.tsx
@@ -46,7 +46,7 @@ export default function ResponsiveNav({ currentPage }: ResponsiveNavProps) {
           borderBottom: isAbout ? '2px solid #4A5D7A' : 'none',
           paddingBottom: isAbout ? '4px' : '0'
         }}>
-          About us
+          About me
         </Link>
         <Link href="/contact" style={{
           color: isContact ? '#4A5D7A' : '#2C3E50', 
@@ -82,7 +82,7 @@ export default function ResponsiveNav({ currentPage }: ResponsiveNavProps) {
       >
         <option value="/">Home</option>
         <option value="/services">Services</option>
-        <option value="/about">About us</option>
+        <option value="/about">About me</option>
         <option value="/contact">Contact us</option>
       </select>
     </>

--- a/components/SimpleMobileNav.tsx
+++ b/components/SimpleMobileNav.tsx
@@ -83,7 +83,7 @@ export default function SimpleMobileNav({ }: SimpleMobileNavProps) {
               borderBottom: '1px solid #eee'
             }}
           >
-            About us
+            About me
           </Link>
           <Link 
             href="/contact/" 

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -30,7 +30,7 @@ export default function About() {
           <nav className="desktop-nav" style={{display: 'flex', gap: '2rem', alignItems: 'center'}}>
             <Link href="/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>Home</Link>
             <Link href="/services/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>Our Work</Link>
-            <Link href="/about" style={{color: '#4A5D7A', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '600', borderBottom: '2px solid #4A5D7A', paddingBottom: '4px'}}>About us</Link>
+            <Link href="/about" style={{color: '#4A5D7A', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '600', borderBottom: '2px solid #4A5D7A', paddingBottom: '4px'}}>About me</Link>
             <Link href="/contact/" style={{color: '#FFFFFF', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500', border: '2px solid #4A5D7A', padding: '8px 12px', borderRadius: '6px', backgroundColor: '#4A5D7A'}}>Free Quote</Link>
           </nav>
           

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -32,7 +32,7 @@ export default function Contact() {
           <nav className="desktop-nav" style={{display: 'flex', gap: '2rem', alignItems: 'center'}}>
             <Link href="/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>Home</Link>
             <Link href="/services/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>Our Work</Link>
-            <Link href="/about/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>About us</Link>
+            <Link href="/about/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>About me</Link>
             <Link href="/contact" style={{color: '#FFFFFF', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '600', border: '2px solid #4A5D7A', padding: '8px 12px', borderRadius: '6px', backgroundColor: '#4A5D7A'}}>Free Quote</Link>
           </nav>
           

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,7 +31,7 @@ export default function Home() {
           <nav className="desktop-nav" style={{display: 'flex', gap: '2rem', alignItems: 'center'}}>
             <Link href="/" style={{color: '#4A5D7A', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '600', borderBottom: '2px solid #4A5D7A', paddingBottom: '4px'}}>Home</Link>
             <Link href="/services/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>Our Work</Link>
-            <Link href="/about/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>About us</Link>
+            <Link href="/about/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>About me</Link>
             <Link href="/contact/" style={{color: '#FFFFFF', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500', border: '2px solid #4A5D7A', padding: '8px 12px', borderRadius: '6px', backgroundColor: '#4A5D7A'}}>Free Quote</Link>
           </nav>
           

--- a/pages/services.tsx
+++ b/pages/services.tsx
@@ -31,7 +31,7 @@ export default function Services() {
           <nav className="desktop-nav" style={{display: 'flex', gap: '2rem', alignItems: 'center'}}>
             <Link href="/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>Home</Link>
             <Link href="/services/" style={{color: '#4A5D7A', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '600', borderBottom: '2px solid #4A5D7A', paddingBottom: '4px'}}>Our Work</Link>
-            <Link href="/about/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>About us</Link>
+            <Link href="/about/" style={{color: '#2C3E50', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500'}}>About me</Link>
             <Link href="/contact/" style={{color: '#FFFFFF', textDecoration: 'none', fontSize: '0.875rem', fontWeight: '500', border: '2px solid #4A5D7A', padding: '8px 12px', borderRadius: '6px', backgroundColor: '#4A5D7A'}}>Free Quote</Link>
           </nav>
           


### PR DESCRIPTION
## Summary
- Updated all navigation references from 'About us' to 'About me' for consistent personal branding

## Changes
- Modified main Navigation component to use 'About me' label
- Updated header navigation on all pages (index, about, services, contact)
- Updated all mobile navigation components for consistency
- Maintains Mason's personal business approach throughout the site

## Files Updated
-  - Main navigation component
- All page headers: , , , 
- All mobile navigation components: , , , , , 

## Test plan
- [x] Verify 'About me' appears in all navigation menus
- [x] Check consistency across desktop and mobile navigation
- [x] Confirm all pages have updated navigation text
- [x] Test build compiles successfully