### PR TITLE
Add navigation functionality to service Get Quote buttons

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -187,19 +187,21 @@ export default function Home() {
                 <li style={{marginBottom: '0.5rem'}}>✓ Streak-free finish</li>
                 <li style={{marginBottom: '0.5rem'}}>✓ Safe for your home</li>
               </ul>
-              <button style={{
-                width: '100%',
-                backgroundColor: '#4A5D7A',
-                color: '#FFFFFF',
-                padding: '12px',
-                borderRadius: '6px',
-                border: 'none',
-                fontSize: '0.875rem',
-                fontWeight: '500',
-                cursor: 'pointer'
-              }}>
-                Get Quote
-              </button>
+              <Link href="/contact">
+                <button style={{
+                  width: '100%',
+                  backgroundColor: '#4A5D7A',
+                  color: '#FFFFFF',
+                  padding: '12px',
+                  borderRadius: '6px',
+                  border: 'none',
+                  fontSize: '0.875rem',
+                  fontWeight: '500',
+                  cursor: 'pointer'
+                }}>
+                  Get Quote
+                </button>
+              </Link>
             </div>
 
             <div className="service-card" style={{backgroundColor: '#FFFFFF', borderRadius: '8px', boxShadow: '0 15px 35px rgba(0, 0, 0, 0.15)', padding: '2.5rem', textAlign: 'center', border: '2px solid #4A5D7A', flex: '0 0 320px', transform: 'scale(1.05)'}}>
@@ -214,19 +216,21 @@ export default function Home() {
                 <li style={{marginBottom: '0.5rem'}}>✓ Complete window refresh</li>
                 <li style={{marginBottom: '0.5rem'}}>✓ Best value service</li>
               </ul>
-              <button style={{
-                width: '100%',
-                backgroundColor: '#4A5D7A',
-                color: '#FFFFFF',
-                padding: '14px',
-                borderRadius: '6px',
-                border: 'none',
-                fontSize: '0.875rem',
-                fontWeight: '600',
-                cursor: 'pointer'
-              }}>
-                Get Quote
-              </button>
+              <Link href="/contact">
+                <button style={{
+                  width: '100%',
+                  backgroundColor: '#4A5D7A',
+                  color: '#FFFFFF',
+                  padding: '14px',
+                  borderRadius: '6px',
+                  border: 'none',
+                  fontSize: '0.875rem',
+                  fontWeight: '600',
+                  cursor: 'pointer'
+                }}>
+                  Get Quote
+                </button>
+              </Link>
             </div>
 
             <div style={{backgroundColor: '#FFFFFF', borderRadius: '8px', boxShadow: '0 10px 25px rgba(0, 0, 0, 0.1)', padding: '2rem', textAlign: 'center', border: '1px solid #FAF9F8', flex: '0 0 300px'}}>
@@ -240,19 +244,21 @@ export default function Home() {
                 <li style={{marginBottom: '0.5rem'}}>✓ Weather damage removal</li>
                 <li style={{marginBottom: '0.5rem'}}>✓ Professional equipment</li>
               </ul>
-              <button style={{
-                width: '100%',
-                backgroundColor: '#4A5D7A',
-                color: '#FFFFFF',
-                padding: '12px',
-                borderRadius: '6px',
-                border: 'none',
-                fontSize: '0.875rem',
-                fontWeight: '500',
-                cursor: 'pointer'
-              }}>
-                Get Quote
-              </button>
+              <Link href="/contact">
+                <button style={{
+                  width: '100%',
+                  backgroundColor: '#4A5D7A',
+                  color: '#FFFFFF',
+                  padding: '12px',
+                  borderRadius: '6px',
+                  border: 'none',
+                  fontSize: '0.875rem',
+                  fontWeight: '500',
+                  cursor: 'pointer'
+                }}>
+                  Get Quote
+                </button>
+              </Link>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Added navigation functionality to all three Get Quote buttons in the services section of the homepage
- Users can now click any service button to navigate directly to the contact form

## Changes
- Wrapped all service Get Quote buttons with Next.js Link components
- Interior Only service button now navigates to /contact page
- Complete Service button now navigates to /contact page
- Exterior Only service button now navigates to /contact page
- Preserved all existing styling and visual appearance

## User Experience Improvements
- Creates seamless flow from service discovery to quote request
- Eliminates dead-end buttons that previously had no functionality
- Consistent navigation behavior across all service offerings
- Direct path for users to request quotes for specific services

## Technical Details
- Used Next.js Link components for proper client-side navigation
- Maintained all existing button styling and hover effects
- No visual changes to the service cards or buttons
- Build tested successfully with no errors

## Test plan
- [x] Verify all three service buttons navigate to contact page
- [x] Confirm button styling remains unchanged
- [x] Test navigation works properly in development
- [x] Validate build compiles without errors